### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # Redis MCP Server (@gongrzhe/server-redis-mcp@1.0.0)
+[![smithery badge](https://smithery.ai/badge/@gongrzhe/server-redis-mcp)](https://smithery.ai/server/@gongrzhe/server-redis-mcp)
 
 A Redis Model Context Protocol (MCP) server implementation for interacting with Redis databases. This server enables LLMs to interact with Redis key-value stores through a set of standardized tools.
 
 ## Installation & Usage
 
+### Installing via Smithery
+
+To install Redis MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@gongrzhe/server-redis-mcp):
+
+```bash
+npx -y @smithery/cli install @gongrzhe/server-redis-mcp --client claude
+```
+
+### Installing Manually
 ```bash
 # Using npx with specific version (recommended)
 npx @gongrzhe/server-redis-mcp@1.0.0 redis://your-redis-host:port


### PR DESCRIPTION
This PR makes the following changes to the README:

1. Adds installation instructions for the Redis MCP Server for Claude Desktop using Smithery CLI. This addition simplifies the installation process for users by streamlining how they can set up the MCP.
2. Introduces a badge showing the number of installations through Smithery. You can view it here: https://smithery.ai/server/@gongrzhe/server-redis-mcp

Please let me know if further adjustments are needed!